### PR TITLE
(place.lat(),place.lng()) instead of (place.xa,place.za)

### DIFF
--- a/src/Ext.ux.GMapPanel3.js
+++ b/src/Ext.ux.GMapPanel3.js
@@ -673,7 +673,7 @@ buttons: [
                 if (accuracy < reqAccuracy) {
                     this.geoErrorMsg(this.geoErrorTitle, String.format(this.geoErrorMsgAccuracy, response[0].geometry.location_type, this.getLocationTypeInfo(response[0].geometry.location_type,'msg')));
                 }else{
-                    point = new google.maps.LatLng(place.xa,place.za);
+                    point = new google.maps.LatLng(place.lat(),place.lng());
                     if (center){
                         this.getMap().setCenter(point, this.zoomLevel);
                         this.lastCenter = point;


### PR DESCRIPTION
In addAddressToMap you use:

var place = response[0].geometry.location;
point = new google.maps.LatLng(place.xa,place.za);

This did not work for me. When debugging place had the values place.Ea place.Fa instead. However it is possible to just use lat() and lng() functions. This looks a bit more stable to me. Or is there another reaso  I missed?

Thanks for providing this nice Ext Component!
